### PR TITLE
[HDX-9779] prep hwa for the stack

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,21 +5,17 @@ WORKDIR /srv/hapi
 COPY . .
 
 RUN apk add \
-        postgresql-dev \
-        unit \
-        unit-python3 && \
+        postgresql-dev && \
     apk --virtual .build-deps add \
         git \
         build-base \
         python3-dev && \
     mkdir -p \
-        /etc/services.d/hapi \
         /var/log/hwa && \
     pip3 --no-cache-dir install --upgrade \
         pip \
         wheel && \
     pip3 install --upgrade -r requirements.txt && \
-    pip3 install elastic-apm && \
     apk del .build-deps && \
     rm -rf /var/lib/apk/* && rm -r /root/.cache
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/unocha/python:3
+FROM public.ecr.aws/unocha/python:3-base
 
 WORKDIR /srv/hapi
 
@@ -6,7 +6,7 @@ COPY . .
 
 RUN apk add \
         postgresql-dev \
-        unit \ 
+        unit \
         unit-python3 && \
     apk --virtual .build-deps add \
         git \
@@ -23,4 +23,6 @@ RUN apk add \
     apk del .build-deps && \
     rm -rf /var/lib/apk/* && rm -r /root/.cache
 
-EXPOSE 5000
+ENTRYPOINT /usr/bin/python
+
+CMD []


### PR DESCRIPTION
We use 3-base tag because we don't need s6init nor any service running in the container.

I configured python as the entrypoint so we only need to supply the python program name.

The container can be started rith `docker-compose run --rm hwa start.py`